### PR TITLE
[WPF] Updated text content rendering to use Text.CurrentValue

### DIFF
--- a/src/Comet.WPF/Handlers/ButtonHandler.cs
+++ b/src/Comet.WPF/Handlers/ButtonHandler.cs
@@ -33,7 +33,7 @@ namespace Comet.WPF.Handlers
         public static void MapTextProperty(IViewHandler viewHandler, Button virtualButton)
         {
             var nativeButton = (WPFButton)viewHandler.NativeView;
-            nativeButton.Content = virtualButton.Text;
+            nativeButton.Content = virtualButton.Text?.CurrentValue ?? string.Empty;
         }
     }
 }

--- a/src/Comet.WPF/Handlers/TextFieldHandler.cs
+++ b/src/Comet.WPF/Handlers/TextFieldHandler.cs
@@ -38,7 +38,7 @@ namespace Comet.WPF.Handlers
         public static void MapTextProperty(IViewHandler viewHandler, TextField virtualView)
         {
             var nativeView = (WPFTextField)viewHandler.NativeView;
-            nativeView.Text = virtualView.Text;
+            nativeView.Text = virtualView.Text?.CurrentValue ?? string.Empty;
             virtualView.InvalidateMeasurement();
         }
         public static void MapTextAlignmentProperty(IViewHandler viewHandler, TextField virtualView)

--- a/src/Comet.WPF/Handlers/TextHandler.cs
+++ b/src/Comet.WPF/Handlers/TextHandler.cs
@@ -24,7 +24,7 @@ namespace Comet.WPF.Handlers
         public static void MapValueProperty(IViewHandler viewHandler, Text virtualView)
         {
             var nativeView = (WPFLabel)viewHandler.NativeView;
-            nativeView.Content = virtualView.Value;
+            nativeView.Content = virtualView.Value?.CurrentValue ?? string.Empty;
             virtualView.InvalidateMeasurement();
         }
 


### PR DESCRIPTION
On WPF the text content on controls wasn't rendered correctly.
Turned out the Content/Text properties of the native controls were set to a property of type Binding<string>.
Updated it to use the CurrentValue property of the Binding<T> class.

### Before:
![cometWpfBefore](https://user-images.githubusercontent.com/13808075/66252227-157b0480-e759-11e9-8c06-a1560b06f59f.jpg)

### After:
![cometWpfAfter](https://user-images.githubusercontent.com/13808075/66252181-8372fc00-e758-11e9-8f74-19ae94d68a73.jpg)

