### PR TITLE
Android text fonts + small fixes

### DIFF
--- a/src/Comet.Android/Controls/CometFragment.cs
+++ b/src/Comet.Android/Controls/CometFragment.cs
@@ -11,6 +11,10 @@ namespace Comet.Android.Controls
         private readonly View view;
         public string Title { get; }
 
+        public CometFragment()
+        {
+        }
+
         public CometFragment(View view)
         {
             this.view = view;

--- a/src/Comet.Android/Handlers/HStackHandler.cs
+++ b/src/Comet.Android/Handlers/HStackHandler.cs
@@ -13,7 +13,7 @@ namespace Comet.Android.Handlers
 
         public HStackHandler() : base(AndroidContext.CurrentContext)
         {
-            Orientation = AOrientation.Vertical;
+            Orientation = AOrientation.Horizontal;
         }
 
         

--- a/src/Comet.Android/Handlers/TextHandler.cs
+++ b/src/Comet.Android/Handlers/TextHandler.cs
@@ -1,4 +1,5 @@
 ﻿using Android.Content;
+using Android.Graphics;
 using Android.Widget;
 using Comet.Android;
 
@@ -20,15 +21,24 @@ namespace Comet.Android.Handlers
             [EnvironmentKeys.Colors.Color] = MapColorProperty,
         };
 
+        private static FontAttributes DefaultFont;
+        static Color DefaultColor;
+
         public TextHandler() : base(Mapper)
         {
         }
-        static Color DefaultColor;
+
         protected override TextView CreateView(Context context)
         {
             var textView = new TextView(context);
             if(DefaultColor == null)
             {
+                DefaultFont = new FontAttributes
+                {
+                    Italic = textView.Typeface.IsItalic,
+                    Size = 16,
+                    Weight = Weight.Regular
+                };
                 DefaultColor = textView.CurrentTextColor.ToColor();
             }
             return textView;
@@ -54,6 +64,26 @@ namespace Comet.Android.Handlers
         
         public static void MapFontProperty(IViewHandler viewHandler, Text virtualView)
         {
+            var nativeView = (TextView)viewHandler.NativeView;
+            var font = virtualView.GetFont(DefaultFont);
+
+            // note: default values (fonts) should be discussed at a more abstract level first
+            if (font == DefaultFont)
+                return;
+
+            TypefaceStyle typefaceStyle = TypefaceStyle.Normal;
+            switch (font.Weight)
+            {
+                case Weight.Bold:
+                    typefaceStyle = font.Italic ? TypefaceStyle.BoldItalic : TypefaceStyle.Bold;
+                    break;
+                case Weight.Regular:
+                    typefaceStyle = font.Italic ? TypefaceStyle.Italic : TypefaceStyle.Normal;
+                    break;
+            }
+            nativeView.SetTypeface(nativeView.Typeface, typefaceStyle);
+            nativeView.TextSize = font.Size;
+            virtualView.InvalidateMeasurement();
         }
 
         public static void MapColorProperty(IViewHandler viewHandler, Text virtualView)
@@ -61,7 +91,6 @@ namespace Comet.Android.Handlers
             var textView = viewHandler.NativeView as TextView;
             var color = virtualView.GetColor(DefaultColor).ToColor();
             textView.SetTextColor(color);
-
         }
     }
 }


### PR DESCRIPTION
This PR includes:
- **Initial support for fonts for Android Text:** Now setting font values won't be ignored anymore. I couldn't really copy what's being done on iOS, because typefaces work pretty different on Android. I also think default values should be discussed at a conceptual level first, I wasn't sure how to implement that on Android (there's no way to get the font name from a TextView for example).
- **Added empty ctor to CometFragment:** Otherwise the sample app (or any Comet app) crashes when rotating the device.
- **Set the orientation of HStack to horizontal on Android:** Well... just that :).


------

#### Personal note

Hey team,

I'm really excited about this project! This is exactly the thing I miss when working with Xamarin :)

I've been experimenting with Comet for the last couple of weeks and I'd love to start contributing to the project. I already joined the convesation in Discord, so please feel free to contact me there.

Cheers! ☄ 