### PR TITLE
Handle the Unchecked event so IsOnChanged fires all the time

### DIFF
--- a/src/Comet.WPF/Handlers/ToggleHandler.cs
+++ b/src/Comet.WPF/Handlers/ToggleHandler.cs
@@ -18,16 +18,18 @@ namespace Comet.WPF.Handlers
 		protected override CheckBox CreateView()
 		{
 			var checkbox = new CheckBox();
-			checkbox.Checked += HandleChecked;
+			checkbox.Checked += HandleCheckedChanged;
+			checkbox.Unchecked += HandleCheckedChanged;
 			return checkbox;
 		}
 
 		protected override void DisposeView(CheckBox checkbox)
 		{
-			checkbox.Checked -= HandleChecked;
+			checkbox.Checked -= HandleCheckedChanged;
+			checkbox.Unchecked -= HandleCheckedChanged;
 		}
 
-		private void HandleChecked(object sender, RoutedEventArgs e) => VirtualView?.IsOnChanged?.Invoke(TypedNativeView.IsChecked ?? false);
+		private void HandleCheckedChanged(object sender, RoutedEventArgs e) => VirtualView?.IsOnChanged?.Invoke(TypedNativeView.IsChecked ?? false);
 
 		public static void MapIsOnProperty(IViewHandler viewHandler, Toggle virtualView)
 		{


### PR DESCRIPTION
WPF checkboxes fire the `Checked` event when the checkbox is turned on, and the `Unchecked` event when the checkbox is turned off. Need to hook up to both events to have `IsOnChanged` fire for any state change.