### PR TITLE
RadioButton/RadioGroup - platform support

### DIFF
--- a/sample/Comet.Android.Sample/Comet.Android.Sample.csproj
+++ b/sample/Comet.Android.Sample/Comet.Android.Sample.csproj
@@ -36,7 +36,13 @@
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
     <LangVersion>latest</LangVersion>
-<AndroidSupportedAbis>x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>
+    </AndroidSupportedAbis>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <BundleAssemblies>false</BundleAssemblies>
+    <MandroidI18n />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>True</DebugSymbols>

--- a/sample/Comet.Mac.Sample/Info.plist
+++ b/sample/Comet.Mac.Sample/Info.plist
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
@@ -28,6 +28,7 @@
 	<string>Main</string>
 	<key>XSAppIconAssets</key>
 	<string>Assets.xcassets/AppIcon.appiconset</string>
-	
+	<key>NSRequiresAquaSystemAppearance</key>
+	<string>true</string>
 </dict>
 </plist>

--- a/sample/Comet.Samples/MainPage.cs
+++ b/sample/Comet.Samples/MainPage.cs
@@ -52,6 +52,7 @@ namespace Comet.Samples
 			new MenuItem("TextFieldSample2", ()=> new TextFieldSample2()),
 			new MenuItem("TextFieldSample3", ()=> new TextFieldSample3()),
 			new MenuItem("TextFieldSample4", ()=> new TextFieldSample4()),
+			new MenuItem("RadioButtonSample", ()=> new RadioButtonSample()),
 			new MenuItem("SkiaSample1 (FingerPaint)", ()=> new SkiaSample1()),
 			new MenuItem("SkiaSample2 (FingerPaint)", ()=> new SkiaSample2()),
 			new MenuItem("SkiaSample3 (BindableFingerPaint)", ()=> new SkiaSample3()),

--- a/sample/Comet.Samples/RadioButtonSample.cs
+++ b/sample/Comet.Samples/RadioButtonSample.cs
@@ -1,0 +1,22 @@
+﻿namespace Comet.Samples
+{
+	public class RadioButtonSample : View
+	{
+		// TODO: Add state to register to Text to display OnClick responses
+
+		[Body]
+		View Body() => new VStack
+		{
+			new RadioButton("Group 1: Option A", true, "group1"),
+			new RadioButton("Group 1: Option B", false, "group1"),
+			new RadioButton("Group 1: Option C", false, "group1"),
+
+			new VStack
+			{
+				new RadioButton("Implicit Group: Option A", true),
+				new RadioButton("Implicit Group: Option B"),
+				new RadioButton("Implicit Group: Option C")
+			}
+		};
+	}
+}

--- a/sample/Comet.Samples/RadioButtonSample.cs
+++ b/sample/Comet.Samples/RadioButtonSample.cs
@@ -5,21 +5,21 @@
 		[Body]
 		View Body() => new VStack
 		{
-			new RadioButton(
-				label: "Group 1: Option A", 
-				selected: true, 
-				groupName: "group1", 
-				onClick: () => System.Diagnostics.Debug.WriteLine("Option A selected")),
-			new RadioButton(
-				label: "Group 1: Option B", 
-				groupName: "group1", 
-				onClick: () => System.Diagnostics.Debug.WriteLine("Option B selected")),
-			new RadioButton(
-				label: "Group 1: Option C", 
-				groupName: "group1", 
-				onClick: () => System.Diagnostics.Debug.WriteLine("Option C selected")),
-
-			new VStack
+			new RadioGroup
+			{
+				new RadioButton(
+					label: "Group 1: Option A",
+					selected: true,
+					onClick: () => System.Diagnostics.Debug.WriteLine("Option A selected")),
+				new RadioButton(
+					label: "Group 1: Option B",
+					onClick: () => System.Diagnostics.Debug.WriteLine("Option B selected")),
+				new RadioButton(
+					label: "Group 1: Option C",
+					onClick: () => System.Diagnostics.Debug.WriteLine("Option C selected")),
+			},
+			new RadioGroup(
+				orientation: Orientation.Horizontal)
 			{
 				new RadioButton(
 					label: "Implicit Group: Option 1",

--- a/sample/Comet.Samples/RadioButtonSample.cs
+++ b/sample/Comet.Samples/RadioButtonSample.cs
@@ -2,20 +2,35 @@
 {
 	public class RadioButtonSample : View
 	{
-		// TODO: Add state to register to Text to display OnClick responses
-
 		[Body]
 		View Body() => new VStack
 		{
-			new RadioButton("Group 1: Option A", true, "group1"),
-			new RadioButton("Group 1: Option B", false, "group1"),
-			new RadioButton("Group 1: Option C", false, "group1"),
+			new RadioButton(
+				label: "Group 1: Option A", 
+				selected: true, 
+				groupName: "group1", 
+				onClick: () => System.Diagnostics.Debug.WriteLine("Option A selected")),
+			new RadioButton(
+				label: "Group 1: Option B", 
+				groupName: "group1", 
+				onClick: () => System.Diagnostics.Debug.WriteLine("Option B selected")),
+			new RadioButton(
+				label: "Group 1: Option C", 
+				groupName: "group1", 
+				onClick: () => System.Diagnostics.Debug.WriteLine("Option C selected")),
 
 			new VStack
 			{
-				new RadioButton("Implicit Group: Option A", true),
-				new RadioButton("Implicit Group: Option B"),
-				new RadioButton("Implicit Group: Option C")
+				new RadioButton(
+					label: "Implicit Group: Option 1",
+					onClick: () => System.Diagnostics.Debug.WriteLine("Option 1 selected")),
+				new RadioButton(
+					label: "Implicit Group: Option 2",
+					selected: true,
+					onClick: () => System.Diagnostics.Debug.WriteLine("Option 2 selected")),
+				new RadioButton(
+					label: "Implicit Group: Option 3",
+					onClick: () => System.Diagnostics.Debug.WriteLine("Option 3 selected"))
 			}
 		};
 	}

--- a/sample/Comet.UWP.Sample/App.xaml
+++ b/sample/Comet.UWP.Sample/App.xaml
@@ -2,6 +2,7 @@
     x:Class="Comet.UWP.Sample.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Comet.UWP.Sample">
+    xmlns:local="using:Comet.UWP.Sample"
+    RequestedTheme="Light">
 
 </Application>

--- a/src/Comet.Android/Comet.Android.csproj
+++ b/src/Comet.Android/Comet.Android.csproj
@@ -15,10 +15,10 @@
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworkVersion>v9.0</TargetFrameworkVersion>
-     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl> 
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>  
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -67,6 +67,8 @@
     <Compile Include="Handlers\AbstractHandler.cs" />
     <Compile Include="Handlers\ButtonHandler.cs" />
     <Compile Include="Handlers\HStackHandler.cs" />
+    <Compile Include="Handlers\RadioButtonHandler.cs" />
+    <Compile Include="Handlers\RadioGroupHandler.cs" />
     <Compile Include="Handlers\SecureFieldHandler.cs" />
     <Compile Include="Handlers\SpacerHandler.cs" />
     <Compile Include="Handlers\TextFieldHandler.cs" />

--- a/src/Comet.Android/Handlers/RadioButtonHandler.cs
+++ b/src/Comet.Android/Handlers/RadioButtonHandler.cs
@@ -1,0 +1,47 @@
+﻿using Android.Content;
+using ARadioButton = Android.Widget.RadioButton;
+
+namespace Comet.Android.Handlers
+{
+	public class RadioButtonHandler : AbstractControlHandler<RadioButton, ARadioButton>
+	{
+		public static readonly PropertyMapper<RadioButton> Mapper = new PropertyMapper<RadioButton>()
+		{
+			[nameof(RadioButton.Label)] = MapLabelProperty,
+			[nameof(RadioButton.Selected)] = MapSelectedProperty
+		};
+
+		public RadioButtonHandler() : base(Mapper)
+		{
+		}
+
+		protected override ARadioButton CreateView(Context context)
+		{
+			var radioButton = new ARadioButton(context);
+			radioButton.Click += HandleClick;
+			return radioButton;
+		}
+
+		protected override void DisposeView(ARadioButton nativeView)
+		{
+			nativeView.Click -= HandleClick;
+		}
+
+		private void HandleClick(object sender, System.EventArgs e)
+		{
+			VirtualView?.OnClick?.Invoke();
+		}
+
+		public static void MapLabelProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (ARadioButton)viewHandler.NativeView;
+			nativeRadioButton.Text = virtualRadioButton.Label.CurrentValue;
+		}
+
+		public static void MapSelectedProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (ARadioButton)viewHandler.NativeView;
+			nativeRadioButton.Selected = virtualRadioButton.Selected;
+		}
+	}
+}

--- a/src/Comet.Android/Handlers/RadioButtonHandler.cs
+++ b/src/Comet.Android/Handlers/RadioButtonHandler.cs
@@ -41,7 +41,7 @@ namespace Comet.Android.Handlers
 		public static void MapSelectedProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
 		{
 			var nativeRadioButton = (ARadioButton)viewHandler.NativeView;
-			nativeRadioButton.Selected = virtualRadioButton.Selected;
+			nativeRadioButton.Checked = virtualRadioButton.Selected;
 		}
 	}
 }

--- a/src/Comet.Android/Handlers/RadioGroupHandler.cs
+++ b/src/Comet.Android/Handlers/RadioGroupHandler.cs
@@ -1,0 +1,261 @@
+﻿using System;
+using System.Drawing;
+using Android.Runtime;
+using Comet.Android.Controls;
+using AView = Android.Views.View;
+using ARadioGroup = Android.Widget.RadioGroup;
+using AViewGroup = Android.Views.ViewGroup;
+
+namespace Comet.Android.Handlers
+{
+	// TODO: This implementation is basically the same as Comet.Android.Handlers.AbstractLaoutHandler.
+	// The primary difference is the base Android type (ViewGroup vs. RadioGroup). 
+	// Work out a way to generalize this better.  
+	// Since most of the implementation is centered around the interface, AndroidViewhandler,
+	// one possibility is to use the C# 8 feature "default interface methods (DIM)"
+	// Another option is to encapsulate the base Android type and expose an instance of that instead of 
+	// derriving from it.
+
+	class RadioGroupHandler : ARadioGroup, AndroidViewHandler
+	{
+		private RadioGroup _view;
+		private bool _inLayout;
+
+		public event EventHandler<ViewChangedEventArgs> NativeViewChanged;
+
+		public RadioGroupHandler() : base(AndroidContext.CurrentContext)
+		{
+
+		}
+
+		public RadioGroupHandler(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+		{
+
+		}
+
+		public AView View => this;
+
+		public CometContainerView ContainerView => null;
+
+		public object NativeView => this;
+
+		public bool HasContainer
+		{
+			get => false;
+			set { }
+		}
+
+		public void SetView(View view)
+		{
+			_view = view as RadioGroup;
+			if (_view != null)
+			{
+				_view.NeedsLayout += HandleNeedsLayout;
+				_view.ChildrenChanged += HandleChildrenChanged;
+				_view.ChildrenAdded += HandleChildrenAdded;
+				_view.ChildrenRemoved += ViewOnChildrenRemoved;
+
+				foreach (var subview in _view)
+				{
+					subview.ViewHandlerChanged += HandleSubviewViewHandlerChanged;
+					if (subview.ViewHandler is AndroidViewHandler handler)
+						handler.NativeViewChanged += HandleSubviewNativeViewChanged;
+
+					var nativeView = subview.ToView() ?? new AView(AndroidContext.CurrentContext);
+					AddView(nativeView);
+				}
+
+				Invalidate();
+			}
+
+			ViewHandler.AddGestures(this, view);
+		}
+
+		public void Remove(View view)
+		{
+			ViewHandler.RemoveGestures(this, view);
+			foreach (var subview in _view)
+			{
+				subview.ViewHandlerChanged -= HandleSubviewViewHandlerChanged;
+				if (subview.ViewHandler is AndroidViewHandler handler)
+					handler.NativeViewChanged -= HandleSubviewNativeViewChanged;
+			}
+
+			_view.NeedsLayout -= HandleNeedsLayout;
+			_view.ChildrenChanged -= HandleChildrenChanged;
+			_view.ChildrenAdded -= HandleChildrenAdded;
+			_view.ChildrenRemoved -= ViewOnChildrenRemoved;
+			_view = null;
+		}
+
+		private void HandleNeedsLayout(object sender, EventArgs e) => Invalidate();
+
+		private void HandleSubviewViewHandlerChanged(object sender, ViewHandlerChangedEventArgs e)
+		{
+			if (e.OldViewHandler is AndroidViewHandler oldHandler)
+				oldHandler.NativeViewChanged -= HandleSubviewNativeViewChanged;
+		}
+
+		private void HandleSubviewNativeViewChanged(object sender, ViewChangedEventArgs args)
+		{
+			if (args.OldNativeView != null)
+			{
+				if (args.OldNativeView.Parent is AViewGroup parent)
+					parent.RemoveView(args.OldNativeView);
+			}
+
+			var index = _view.IndexOf(args.VirtualView);
+			var newView = args.NewNativeView ?? new AView(AndroidContext.CurrentContext);
+			AddView(newView, index);
+		}
+
+		public virtual void UpdateValue(string property, object value)
+		{
+			if (property == Gesture.AddGestureProperty)
+			{
+				ViewHandler.AddGesture(this, (Gesture)value);
+			}
+			else if (property == Gesture.RemoveGestureProperty)
+			{
+				ViewHandler.RemoveGesture(this, (Gesture)value);
+			}
+		}
+
+		private void HandleChildrenAdded(object sender, LayoutEventArgs e)
+		{
+			for (var i = 0; i < e.Count; i++)
+			{
+				var index = e.Start + i;
+				var view = _view[index];
+
+				view.ViewHandlerChanged += HandleSubviewViewHandlerChanged;
+				if (view.ViewHandler is AndroidViewHandler handler)
+					handler.NativeViewChanged += HandleSubviewNativeViewChanged;
+
+				var nativeView = view.ToView() ?? new AView(AndroidContext.CurrentContext);
+				AddView(nativeView, index);
+			}
+
+			Invalidate();
+		}
+
+		private void ViewOnChildrenRemoved(object sender, LayoutEventArgs e)
+		{
+			if (e.Removed != null)
+			{
+				foreach (var view in e.Removed)
+				{
+					view.ViewHandlerChanged -= HandleSubviewViewHandlerChanged;
+					if (view.ViewHandler is AndroidViewHandler handler)
+						handler.NativeViewChanged -= HandleSubviewNativeViewChanged;
+				}
+			}
+
+			for (var i = 0; i < e.Count; i++)
+			{
+				var index = e.Start + i;
+				RemoveViewAt(index);
+			}
+
+			Invalidate();
+		}
+
+		private void HandleChildrenChanged(object sender, LayoutEventArgs e)
+		{
+			if (e.Removed != null)
+			{
+				foreach (var view in e.Removed)
+				{
+					view.ViewHandlerChanged -= HandleSubviewViewHandlerChanged;
+					if (view.ViewHandler is AndroidViewHandler handler)
+						handler.NativeViewChanged -= HandleSubviewNativeViewChanged;
+				}
+			}
+
+			for (var i = 0; i < e.Count; i++)
+			{
+				var index = e.Start + i;
+				RemoveViewAt(index);
+
+				var view = _view[index];
+
+				view.ViewHandlerChanged += HandleSubviewViewHandlerChanged;
+				if (view.ViewHandler is AndroidViewHandler handler)
+					handler.NativeViewChanged += HandleSubviewNativeViewChanged;
+
+				var newNativeView = view.ToView() ?? new AView(AndroidContext.CurrentContext);
+				AddView(newNativeView, index);
+			}
+
+			Invalidate();
+		}
+
+		public CometTouchGestureListener GestureListener { get; set; }
+
+		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		{
+			if (_view == null) return;
+
+			var width = MeasureSpec.GetSize(widthMeasureSpec);
+			var height = MeasureSpec.GetSize(heightMeasureSpec);
+
+			var measured = _view.Measure(new SizeF(width, height));
+
+			// The measured size is in display independent units, so we need to get the display metrics and
+			// scale them back to display specific units.
+			var density = AndroidContext.DisplayScale;
+
+			var scaledWidth = measured.Width * density;
+			var scaledHeight = measured.Height * density;
+
+			SetMeasuredDimension((int)scaledWidth, (int)scaledHeight);
+		}
+
+		public SizeF GetIntrinsicSize(SizeF availableSize) => Comet.View.UseAvailableWidthAndHeight;
+
+		public void SetFrame(RectangleF frame)
+		{
+			if (_inLayout)
+				return;
+
+			var scale = AndroidContext.DisplayScale;
+
+			var left = frame.Left * scale;
+			var top = frame.Top * scale;
+			var bottom = frame.Bottom * scale;
+			var right = frame.Right * scale;
+
+			if (LayoutParameters == null)
+			{
+				LayoutParameters = new AViewGroup.LayoutParams(
+					(int)(frame.Width * scale),
+					(int)(frame.Height * scale));
+			}
+			else
+			{
+				LayoutParameters.Width = (int)(frame.Width * scale);
+				LayoutParameters.Height = (int)(frame.Height * scale);
+			}
+
+			Layout((int)left, (int)top, (int)right, (int)bottom);
+		}
+
+		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+		{
+			if (_view == null || !changed || _inLayout) return;
+
+			var displayScale = AndroidContext.DisplayScale;
+			var width = (right - left) / displayScale;
+			var height = (bottom - top) / displayScale;
+
+			if (width > 0 && height > 0)
+			{
+				_inLayout = true;
+				var x = left / displayScale;
+				var y = top / displayScale;
+				_view.Frame = new RectangleF(x, y, width, height);
+				_inLayout = false;
+			}
+		}
+	}
+}

--- a/src/Comet.Android/UI.cs
+++ b/src/Comet.Android/UI.cs
@@ -21,6 +21,7 @@ namespace Comet.Android
 			Registrar.Handlers.Register<ProgressBar, ProgressBarHandler>();
 			Registrar.Handlers.Register<SecureField, SecureFieldHandler>();
 			Registrar.Handlers.Register<Slider, SliderHandler>();
+			Registrar.Handlers.Register<RadioButton, RadioButtonHandler>();
 			// Stepper
 			Registrar.Handlers.Register<Text, TextHandler>();
 			Registrar.Handlers.Register<TextField, TextFieldHandler>();
@@ -35,6 +36,7 @@ namespace Comet.Android
 			Registrar.Handlers.Register<ViewRepresentable, ViewRepresentableHandler>();
 			Registrar.Handlers.Register<TabView, TabViewHandler>();
 			Registrar.Handlers.Register<NavigationView, NavigationViewHandler>();
+			Registrar.Handlers.Register<RadioGroup, RadioGroupHandler>();
 
 			// Layouts
 			Registrar.Handlers.Register<HStack, HStackHandler>();

--- a/src/Comet.Mac/Comet.Mac.csproj
+++ b/src/Comet.Mac/Comet.Mac.csproj
@@ -114,6 +114,8 @@
     <Compile Include="Handlers\ListViewHandler.cs" />
     <Compile Include="Controls\CUITableViewCell.cs" />
     <Compile Include="Services\MacTicker.cs" />
+    <Compile Include="Handlers\RadioGroupHandler.cs" />
+    <Compile Include="Handlers\RadioButtonHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Comet\Comet.csproj">

--- a/src/Comet.Mac/Handlers/RadioButtonHandler.cs
+++ b/src/Comet.Mac/Handlers/RadioButtonHandler.cs
@@ -1,0 +1,60 @@
+﻿using AppKit;
+
+namespace Comet.Mac.Handlers
+{
+	public class RadioButtonHandler : AbstractControlHandler<RadioButton, NSButton>
+	{
+		public static readonly PropertyMapper<RadioButton> Mapper = new PropertyMapper<RadioButton>()
+		{
+			[nameof(RadioButton.Label)] = MapLabelProperty,
+			[nameof(RadioButton.Selected)] = MapSelectedProperty
+		};
+
+		public RadioButtonHandler() : base(Mapper)
+		{
+		}
+
+		protected override NSButton CreateView()
+		{
+			var button = NSButton.CreateRadioButton(VirtualView.Label.CurrentValue, RadioAction);
+
+			button.State = VirtualView.Selected
+				? NSCellStateValue.On
+				: NSCellStateValue.Off;
+
+			button.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSizeForControlSize(NSControlSize.Regular));
+			button.Activated += HandleTouchUpInside;
+
+			return button;
+		}
+
+		private void RadioAction()
+		{
+
+		}
+
+		protected override void DisposeView(NSButton nativeView)
+		{
+			nativeView.Activated -= HandleTouchUpInside;
+		}
+
+		private void HandleTouchUpInside(object sender, System.EventArgs e)
+		{
+			VirtualView?.OnClick?.Invoke();
+		}
+
+		public static void MapLabelProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (NSButton)viewHandler.NativeView;
+			nativeRadioButton.Title = virtualRadioButton.Label.CurrentValue;
+		}
+
+		public static void MapSelectedProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (NSButton)viewHandler.NativeView;
+			nativeRadioButton.State = virtualRadioButton.Selected
+				? NSCellStateValue.On
+				: NSCellStateValue.Off;
+		}
+	}
+}

--- a/src/Comet.Mac/Handlers/RadioGroupHandler.cs
+++ b/src/Comet.Mac/Handlers/RadioGroupHandler.cs
@@ -1,0 +1,16 @@
+﻿using CoreGraphics;
+
+namespace Comet.Mac.Handlers
+{
+	class RadioGroupHandler : AbstractLayoutHandler
+	{
+		public RadioGroupHandler()
+		{
+		}
+
+		public RadioGroupHandler(CGRect rect) : base(rect)
+		{
+
+		}
+	}
+}

--- a/src/Comet.Mac/UI.cs
+++ b/src/Comet.Mac/UI.cs
@@ -23,6 +23,7 @@ namespace Comet.Mac
 			Registrar.Handlers.Register<Slider, SliderHandler>();
 			Registrar.Handlers.Register<ShapeView, ShapeViewHandler>();
 			Registrar.Handlers.Register<Toggle, ToggleHandler>();
+			Registrar.Handlers.Register<RadioButton, RadioButtonHandler>();
 			//Registrar.Handlers.Register<WebView, WebViewHandler> ();
 
 			// Containers
@@ -31,6 +32,7 @@ namespace Comet.Mac
 			Registrar.Handlers.Register<ContentView, ContentViewHandler>();
 			Registrar.Handlers.Register<ListView, ListViewHandler>();
 			Registrar.Handlers.Register<ViewRepresentable, ViewRepresentableHandler>();
+			Registrar.Handlers.Register<RadioGroup, RadioGroupHandler>();
 
 			// Managed Layout
 			Registrar.Handlers.Register<HStack, HStackHandler>();

--- a/src/Comet.UWP/Comet.UWP.csproj
+++ b/src/Comet.UWP/Comet.UWP.csproj
@@ -138,6 +138,7 @@
     <Compile Include="Handlers\ManagedHStackHandler.cs" />
     <Compile Include="Handlers\ProgressBarHandler.cs" />
     <Compile Include="Handlers\RadioButtonHandler.cs" />
+    <Compile Include="Handlers\RadioGroupHandler.cs" />
     <Compile Include="Handlers\ShapeViewHandler.cs" />
     <Compile Include="Handlers\SpacerHandler.cs" />
     <Compile Include="Handlers\ToggleHandler.cs" />

--- a/src/Comet.UWP/Comet.UWP.csproj
+++ b/src/Comet.UWP/Comet.UWP.csproj
@@ -16,10 +16,10 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl> 
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>  
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -137,6 +137,7 @@
     <Compile Include="Handlers\ManagedZStackHandler.cs" />
     <Compile Include="Handlers\ManagedHStackHandler.cs" />
     <Compile Include="Handlers\ProgressBarHandler.cs" />
+    <Compile Include="Handlers\RadioButtonHandler.cs" />
     <Compile Include="Handlers\ShapeViewHandler.cs" />
     <Compile Include="Handlers\SpacerHandler.cs" />
     <Compile Include="Handlers\ToggleHandler.cs" />

--- a/src/Comet.UWP/Handlers/RadioButtonHandler.cs
+++ b/src/Comet.UWP/Handlers/RadioButtonHandler.cs
@@ -1,0 +1,53 @@
+﻿using UWPRadioButton = Windows.UI.Xaml.Controls.RadioButton;
+
+namespace Comet.UWP.Handlers
+{
+	public class RadioButtonHandler : AbstractControlHandler<RadioButton, UWPRadioButton>
+	{
+		public static readonly PropertyMapper<RadioButton> Mapper = new PropertyMapper<RadioButton>()
+		{
+			[nameof(RadioButton.Label)] = MapLabelProperty,
+			[nameof(RadioButton.Selected)] = MapSelectedProperty,
+			[nameof(RadioButton.GroupName)] = MapGroupnameProperty
+		};
+
+		public RadioButtonHandler() : base(Mapper)
+		{
+		}
+
+		protected override UWPRadioButton CreateView()
+		{
+			var radioButton = new UWPRadioButton();
+			radioButton.Click += HandleClick;
+			return radioButton;
+		}
+
+		protected override void DisposeView(UWPRadioButton nativeView)
+		{
+			nativeView.Click -= HandleClick;
+		}
+
+		private void HandleClick(object sender, Windows.UI.Xaml.RoutedEventArgs e)
+		{
+			VirtualView?.OnClick?.Invoke();
+		}
+
+		public static void MapLabelProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (UWPRadioButton)viewHandler.NativeView;
+			nativeRadioButton.Content = virtualRadioButton.Label.CurrentValue;
+		}
+
+		public static void MapSelectedProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (UWPRadioButton)viewHandler.NativeView;
+			nativeRadioButton.IsChecked = virtualRadioButton.Selected;
+		}
+
+		public static void MapGroupnameProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (UWPRadioButton)viewHandler.NativeView;
+			nativeRadioButton.GroupName = virtualRadioButton.GroupName ?? string.Empty;
+		}
+	}
+}

--- a/src/Comet.UWP/Handlers/RadioButtonHandler.cs
+++ b/src/Comet.UWP/Handlers/RadioButtonHandler.cs
@@ -7,8 +7,7 @@ namespace Comet.UWP.Handlers
 		public static readonly PropertyMapper<RadioButton> Mapper = new PropertyMapper<RadioButton>()
 		{
 			[nameof(RadioButton.Label)] = MapLabelProperty,
-			[nameof(RadioButton.Selected)] = MapSelectedProperty,
-			[nameof(RadioButton.GroupName)] = MapGroupnameProperty
+			[nameof(RadioButton.Selected)] = MapSelectedProperty
 		};
 
 		public RadioButtonHandler() : base(Mapper)
@@ -42,12 +41,6 @@ namespace Comet.UWP.Handlers
 		{
 			var nativeRadioButton = (UWPRadioButton)viewHandler.NativeView;
 			nativeRadioButton.IsChecked = virtualRadioButton.Selected;
-		}
-
-		public static void MapGroupnameProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
-		{
-			var nativeRadioButton = (UWPRadioButton)viewHandler.NativeView;
-			nativeRadioButton.GroupName = virtualRadioButton.GroupName ?? string.Empty;
 		}
 	}
 }

--- a/src/Comet.UWP/Handlers/RadioGroupHandler.cs
+++ b/src/Comet.UWP/Handlers/RadioGroupHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace Comet.UWP.Handlers
+{
+	public class RadioGroupHandler : AbstractLayoutHandler
+	{
+
+	}
+}

--- a/src/Comet.UWP/UI.cs
+++ b/src/Comet.UWP/UI.cs
@@ -24,6 +24,7 @@ namespace Comet.UWP
 			Registrar.Handlers.Register<Toggle, ToggleHandler>();
 			Registrar.Handlers.Register<ProgressBar, ProgressBarHandler>();
 			Registrar.Handlers.Register<ShapeView, ShapeViewHandler>();
+			Registrar.Handlers.Register<RadioButton, RadioButtonHandler>();
 			//Registrar.Handlers.Register<WebView, WebViewHandler> ();
 
 			// Containers

--- a/src/Comet.UWP/UI.cs
+++ b/src/Comet.UWP/UI.cs
@@ -32,6 +32,7 @@ namespace Comet.UWP
 			Registrar.Handlers.Register<ListView, ListViewHandler>();
 			Registrar.Handlers.Register<ScrollView, ScrollViewHandler>();
 			Registrar.Handlers.Register<View, ViewHandler>();
+			Registrar.Handlers.Register<RadioGroup, RadioGroupHandler>();
 
 			// Common Layout
 			Registrar.Handlers.Register<Spacer, SpacerHandler>();

--- a/src/Comet.WPF/Comet.WPF.csproj
+++ b/src/Comet.WPF/Comet.WPF.csproj
@@ -12,10 +12,10 @@
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <Deterministic>true</Deterministic>
-     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl> 
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>  
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -70,6 +70,7 @@
     <Compile Include="Handlers\ManagedHStackHandler.cs" />
     <Compile Include="Handlers\ManagedVStackHandler.cs" />
     <Compile Include="Handlers\ManagedZStackHandler.cs" />
+    <Compile Include="Handlers\RadioButtonHandler.cs" />
     <Compile Include="Handlers\ScrollViewHandler.cs" />
     <Compile Include="Handlers\SpacerHandler.cs" />
     <Compile Include="Handlers\TextFieldHandler.cs" />

--- a/src/Comet.WPF/Comet.WPF.csproj
+++ b/src/Comet.WPF/Comet.WPF.csproj
@@ -71,6 +71,7 @@
     <Compile Include="Handlers\ManagedVStackHandler.cs" />
     <Compile Include="Handlers\ManagedZStackHandler.cs" />
     <Compile Include="Handlers\RadioButtonHandler.cs" />
+    <Compile Include="Handlers\RadioGroupHandler.cs" />
     <Compile Include="Handlers\ScrollViewHandler.cs" />
     <Compile Include="Handlers\SpacerHandler.cs" />
     <Compile Include="Handlers\TextFieldHandler.cs" />

--- a/src/Comet.WPF/Handlers/RadioButtonHandler.cs
+++ b/src/Comet.WPF/Handlers/RadioButtonHandler.cs
@@ -1,0 +1,53 @@
+﻿using WPFRadioButton = System.Windows.Controls.RadioButton;
+
+namespace Comet.WPF.Handlers
+{
+	public class RadioButtonHandler : AbstractControlHandler<RadioButton, WPFRadioButton>
+	{
+		public static readonly PropertyMapper<RadioButton> Mapper = new PropertyMapper<RadioButton>()
+		{
+			[nameof(RadioButton.Label)] = MapLabelProperty,
+			[nameof(RadioButton.Selected)] = MapSelectedProperty,
+			[nameof(RadioButton.GroupName)] = MapGroupnameProperty
+		};
+
+		public RadioButtonHandler() : base(Mapper)
+		{
+		}
+
+		protected override WPFRadioButton CreateView()
+		{
+			var radioButton = new WPFRadioButton();
+			radioButton.Click += HandleClick;
+			return radioButton;
+		}
+
+		protected override void DisposeView(WPFRadioButton nativeView)
+		{
+			nativeView.Click -= HandleClick;
+		}
+
+		private void HandleClick(object sender, System.Windows.RoutedEventArgs e)
+		{
+			VirtualView?.OnClick?.Invoke();
+		}
+
+		public static void MapLabelProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (WPFRadioButton)viewHandler.NativeView;
+			nativeRadioButton.Content = virtualRadioButton.Label.CurrentValue;
+		}
+
+		public static void MapSelectedProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (WPFRadioButton)viewHandler.NativeView;
+			nativeRadioButton.IsChecked = virtualRadioButton.Selected;
+		}
+
+		public static void MapGroupnameProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (WPFRadioButton)viewHandler.NativeView;
+			nativeRadioButton.GroupName = virtualRadioButton.GroupName ?? string.Empty;
+		}
+	}
+}

--- a/src/Comet.WPF/Handlers/RadioButtonHandler.cs
+++ b/src/Comet.WPF/Handlers/RadioButtonHandler.cs
@@ -7,8 +7,7 @@ namespace Comet.WPF.Handlers
 		public static readonly PropertyMapper<RadioButton> Mapper = new PropertyMapper<RadioButton>()
 		{
 			[nameof(RadioButton.Label)] = MapLabelProperty,
-			[nameof(RadioButton.Selected)] = MapSelectedProperty,
-			[nameof(RadioButton.GroupName)] = MapGroupnameProperty
+			[nameof(RadioButton.Selected)] = MapSelectedProperty
 		};
 
 		public RadioButtonHandler() : base(Mapper)
@@ -42,12 +41,6 @@ namespace Comet.WPF.Handlers
 		{
 			var nativeRadioButton = (WPFRadioButton)viewHandler.NativeView;
 			nativeRadioButton.IsChecked = virtualRadioButton.Selected;
-		}
-
-		public static void MapGroupnameProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
-		{
-			var nativeRadioButton = (WPFRadioButton)viewHandler.NativeView;
-			nativeRadioButton.GroupName = virtualRadioButton.GroupName ?? string.Empty;
 		}
 	}
 }

--- a/src/Comet.WPF/Handlers/RadioGroupHandler.cs
+++ b/src/Comet.WPF/Handlers/RadioGroupHandler.cs
@@ -1,0 +1,7 @@
+﻿namespace Comet.WPF.Handlers
+{
+	class RadioGroupHandler : AbstractLayoutHandler
+	{
+
+	}
+}

--- a/src/Comet.WPF/UI.cs
+++ b/src/Comet.WPF/UI.cs
@@ -19,6 +19,7 @@ namespace Comet.WPF
 			Registrar.Handlers.Register<Text, TextHandler>();
 			Registrar.Handlers.Register<TextField, TextFieldHandler>();
 			Registrar.Handlers.Register<Toggle, ToggleHandler>();
+			Registrar.Handlers.Register<RadioButton, RadioButtonHandler>();
 			//Registrar.Handlers.Register<WebView, WebViewHandler> ();
 
 			// Containers

--- a/src/Comet.WPF/UI.cs
+++ b/src/Comet.WPF/UI.cs
@@ -27,6 +27,7 @@ namespace Comet.WPF
 			Registrar.Handlers.Register<ListView, ListViewHandler>();
 			Registrar.Handlers.Register<View, ViewHandler>();
 			Registrar.Handlers.Register<ContentView, ContentViewHandler>();
+			Registrar.Handlers.Register<RadioGroup, RadioGroupHandler>();
 
 			// Common Layout
 			Registrar.Handlers.Register<Spacer, SpacerHandler>();

--- a/src/Comet.iOS/Comet.iOS.csproj
+++ b/src/Comet.iOS/Comet.iOS.csproj
@@ -13,10 +13,10 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Comet.iOS</AssemblyName>
     <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
-     <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
-    <PublishRepositoryUrl>true</PublishRepositoryUrl> 
+    <!-- Optional: Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <!-- Optional: Embed source files that are not tracked by the source control manager in the PDB -->
-    <EmbedUntrackedSources>true</EmbedUntrackedSources>  
+    <EmbedUntrackedSources>true</EmbedUntrackedSources>
     <!-- Optional: Build symbol package (.snupkg) to distribute the PDB containing Source Link -->
     <IncludeSymbols>true</IncludeSymbols>
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
@@ -51,6 +51,7 @@
   <ItemGroup>
     <Compile Include="Controls\CUIContainerView.cs" />
     <Compile Include="Controls\CUIImageView.cs" />
+    <Compile Include="Controls\CUIRadioButton.cs" />
     <Compile Include="Controls\CUITableView.cs" />
     <Compile Include="Controls\CUITableViewCell.cs" />
     <Compile Include="Controls\SizeChangedEventArgs.cs" />
@@ -60,6 +61,8 @@
     <Compile Include="Handlers\AbstractLayoutHandler.cs" />
     <Compile Include="Handlers\GridHandler.cs" />
     <Compile Include="Handlers\HStackHandler.cs" />
+    <Compile Include="Handlers\RadioButtonHandler.cs" />
+    <Compile Include="Handlers\RadioGroupHandler.cs" />
     <Compile Include="Handlers\SecureFieldHandler.cs" />
     <Compile Include="Handlers\SliderHandler.cs" />
     <Compile Include="Handlers\SpacerHandler.cs" />

--- a/src/Comet.iOS/Controls/CUIRadioButton.cs
+++ b/src/Comet.iOS/Controls/CUIRadioButton.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using UIKit;
+
+namespace Comet.iOS
+{
+	class CUIRadioButton : UIButton
+	{
+		private const float CONTENT_SPACING = 10;
+
+		private static UIImage SelectedImage = UIImage.GetSystemImage("largecircle.fill.circle")
+			.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+		private static UIImage DeselectedImage = UIImage.GetSystemImage("circle")
+			.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
+
+		public event EventHandler IsCheckedChanged;
+
+		public CUIRadioButton(bool isChecked = false)
+		{
+			SetImage(_isChecked ? SelectedImage : DeselectedImage, UIControlState.Normal);
+			IsChecked = isChecked;
+
+			SetTitleColor(UIColor.Blue, UIControlState.Normal);
+
+			ContentEdgeInsets = new UIEdgeInsets(0, CONTENT_SPACING, 0, CONTENT_SPACING);
+			TitleEdgeInsets = new UIEdgeInsets(0, CONTENT_SPACING, 0, -CONTENT_SPACING);
+
+			TouchUpInside += (sender, e) => { if (!IsChecked) IsChecked = true; };
+		}
+
+		public override void SetTitleColor(UIColor color, UIControlState forState)
+		{
+			base.SetTitleColor(color, forState);
+
+			if (forState == UIControlState.Normal)
+			{
+				ImageView.TintColor = color;
+			}
+		}
+
+		private bool _isChecked = false;
+
+		public bool IsChecked
+		{
+			get => _isChecked;
+			set
+			{
+				if (_isChecked != value)
+				{
+					_isChecked = value;
+					SetImage(_isChecked ? SelectedImage : DeselectedImage, UIControlState.Normal);
+					IsCheckedChanged?.Invoke(this, new EventArgs());
+				}
+			}
+		}
+	}
+}

--- a/src/Comet.iOS/Handlers/RadioButtonHandler.cs
+++ b/src/Comet.iOS/Handlers/RadioButtonHandler.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using UIKit;
+
+namespace Comet.iOS.Handlers
+{
+	class RadioButtonHandler : AbstractControlHandler<RadioButton, CUIRadioButton>
+	{
+		public static readonly PropertyMapper<RadioButton> Mapper = new PropertyMapper<RadioButton>()
+		{
+			[nameof(RadioButton.Label)] = MapLabelProperty,
+			[nameof(RadioButton.Selected)] = MapSelectedProperty
+		};
+
+		public RadioButtonHandler() : base(Mapper)
+		{
+		}
+
+		protected override CUIRadioButton CreateView()
+		{
+			var button = new CUIRadioButton(VirtualView.Selected);
+
+			button.TouchUpInside += HandleTouchUpInside;
+
+			return button;
+		}
+		
+		protected override void DisposeView(CUIRadioButton nativeView)
+		{
+			nativeView.TouchUpInside -= HandleTouchUpInside;
+		}
+
+		private void HandleTouchUpInside(object sender, EventArgs e) => VirtualView?.OnClick?.Invoke();
+
+		public static void MapLabelProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (CUIRadioButton)viewHandler.NativeView;
+			nativeRadioButton.SetTitle(virtualRadioButton.Label?.CurrentValue, UIControlState.Normal);
+			virtualRadioButton.InvalidateMeasurement();
+		}
+
+		public static void MapSelectedProperty(IViewHandler viewHandler, RadioButton virtualRadioButton)
+		{
+			var nativeRadioButton = (CUIRadioButton)viewHandler.NativeView;
+			nativeRadioButton.IsChecked = virtualRadioButton.Selected;
+		}
+	}
+}

--- a/src/Comet.iOS/Handlers/RadioGroupHandler.cs
+++ b/src/Comet.iOS/Handlers/RadioGroupHandler.cs
@@ -1,0 +1,63 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using CoreGraphics;
+using UIKit;
+
+namespace Comet.iOS.Handlers
+{
+	class RadioGroupHandler : AbstractLayoutHandler
+	{
+		private List<CUIRadioButton> RadioButtons = new List<CUIRadioButton>();
+
+		public RadioGroupHandler(CGRect rect) : base(rect)
+		{
+		}
+
+		public RadioGroupHandler() : base()
+		{
+		}
+
+		public override void SubviewAdded(UIView uiview)
+		{
+			base.SubviewAdded(uiview);
+
+			var radioButton = (CUIRadioButton)uiview;
+			radioButton.IsCheckedChanged += HandleIsCheckedChanged;
+			RadioButtons.Add(radioButton);
+		}
+		
+		public override void WillRemoveSubview(UIView uiview)
+		{
+			base.WillRemoveSubview(uiview);
+
+			var radioButton = (CUIRadioButton)uiview;
+			radioButton.IsCheckedChanged -= HandleIsCheckedChanged;
+			RadioButtons.Remove(radioButton);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			foreach(var button in RadioButtons)
+			{
+				button.IsCheckedChanged -= HandleIsCheckedChanged;
+			}
+
+			RadioButtons.Clear();
+
+			base.Dispose(disposing);
+		}
+
+		private void HandleIsCheckedChanged(object sender, System.EventArgs e)
+		{
+			var changedButton = (CUIRadioButton)sender;
+
+			if (changedButton.IsChecked)
+			{
+				foreach(var button in RadioButtons.Where(_ => _ != changedButton))
+				{
+					button.IsChecked = false;
+				}
+			}
+		}
+	}
+}

--- a/src/Comet.iOS/UI.cs
+++ b/src/Comet.iOS/UI.cs
@@ -27,6 +27,7 @@ namespace Comet.iOS
 			Registrar.Handlers.Register<Text, TextHandler>();
 			Registrar.Handlers.Register<TextField, TextFieldHandler>();
 			Registrar.Handlers.Register<Toggle, ToggleHandler>();
+			Registrar.Handlers.Register<RadioButton, RadioButtonHandler>();
 			//Registrar.Handlers.Register<WebView, WebViewHandler> ();
 
 			// Containers
@@ -43,6 +44,7 @@ namespace Comet.iOS
 			Registrar.Handlers.Register<ZStack, ZStackHandler>();
 			Registrar.Handlers.Register<Grid, GridHandler>();
 			Registrar.Handlers.Register<Spacer, SpacerHandler>();
+			Registrar.Handlers.Register<RadioGroup, RadioGroupHandler>();
 
 			// Device Features
 			ModalView.PerformPresent = (o) => {

--- a/src/Comet/Controls/AbstractLayout.cs
+++ b/src/Comet/Controls/AbstractLayout.cs
@@ -41,7 +41,7 @@ namespace Comet
 		protected override void Dispose(bool disposing)
 		{
 			base.Dispose(disposing);
-			_layout.Invalidate();
+			_layout?.Invalidate();
 		}
 	}
 }

--- a/src/Comet/Controls/RadioButton.cs
+++ b/src/Comet/Controls/RadioButton.cs
@@ -7,24 +7,20 @@ namespace Comet
 		public RadioButton(
 			Binding<string> label = null,
 			Binding<bool> selected = null,
-			Binding<string> groupName = null,
 			Action onClick = null)
 		{
 			Label = label;
 			Selected = selected;
-			GroupName = groupName;
 			OnClick = onClick;
 		}
 
 		public RadioButton(
 			Func<string> label,
 			Func<bool> selected = null,
-			Func<string> groupName = null,
 			Action onClick = null)
 			: this(
 				  (Binding<string>)label,
 				  (Binding<bool>)selected,
-				  (Binding<string>)groupName,
 				  onClick)
 		{
 
@@ -44,14 +40,20 @@ namespace Comet
 			private set => this.SetBindingValue(ref _selected, value);
 		}
 
-		Binding<string> _groupName;
-		public Binding<string> GroupName
-		{
-			get => _groupName;
-			private set => this.SetBindingValue(ref _groupName, value);
-		}
-
 		public Action OnClick { get; private set; }
+
+		protected override View GetRenderView()
+		{
+			View view =  base.GetRenderView();
+
+			if (view.Parent is RadioGroup)
+			{
+				return view;
+			}
+
+			// TODO: Create Comet-specific UI exceptions
+			throw new Exception("A RadioButton must be in a RadioGroup");
+		}
 	}
 }
  

--- a/src/Comet/Controls/RadioButton.cs
+++ b/src/Comet/Controls/RadioButton.cs
@@ -1,0 +1,57 @@
+﻿using System;
+
+namespace Comet
+{
+	public class RadioButton : View
+	{
+		public RadioButton(
+			Binding<string> label = null,
+			Binding<bool> selected = null,
+			Binding<string> groupName = null,
+			Action onClick = null)
+		{
+			Label = label;
+			Selected = selected;
+			GroupName = groupName;
+			OnClick = onClick;
+		}
+
+		public RadioButton(
+			Func<string> label,
+			Func<bool> selected = null,
+			Func<string> groupName = null,
+			Action onClick = null)
+			: this(
+				  (Binding<string>)label,
+				  (Binding<bool>)selected,
+				  (Binding<string>)groupName,
+				  onClick)
+		{
+
+		}
+
+		Binding<string> _label;
+		public Binding<string> Label
+		{
+			get => _label;
+			private set => this.SetBindingValue(ref _label, value);
+		}
+
+		Binding<bool> _selected;
+		public Binding<bool> Selected
+		{
+			get => _selected;
+			private set => this.SetBindingValue(ref _selected, value);
+		}
+
+		Binding<string> _groupName;
+		public Binding<string> GroupName
+		{
+			get => _groupName;
+			private set => this.SetBindingValue(ref _groupName, value);
+		}
+
+		public Action OnClick { get; private set; }
+	}
+}
+ 

--- a/src/Comet/Controls/RadioGroup.cs
+++ b/src/Comet/Controls/RadioGroup.cs
@@ -1,0 +1,29 @@
+﻿using Comet.Layout;
+
+namespace Comet
+{
+	public class RadioGroup : AbstractLayout
+	{
+		public RadioGroup(Orientation orientation = Orientation.Vertical) 
+			: base(orientation == Orientation.Vertical
+				  ? (ILayoutManager)new VStackLayoutManager()
+				  : (ILayoutManager)new HStackLayoutManager())
+		{
+			Orientation = orientation;
+		}
+
+		public Orientation Orientation { get; }
+
+		protected override void OnAdded(View view)
+		{
+			if (view is RadioButton)
+			{
+				base.OnAdded(view);
+			}
+			else
+			{
+				throw new System.Exception("A RadioGroup may only contain RadioButtons");
+			}
+		}
+	}
+}

--- a/src/Comet/Layout/HStackLayoutManager.cs
+++ b/src/Comet/Layout/HStackLayoutManager.cs
@@ -10,8 +10,8 @@ namespace Comet.Layout
 		private readonly float _spacing;
 
 		public HStackLayoutManager(
-			VerticalAlignment alignment,
-			float? spacing)
+			VerticalAlignment alignment = VerticalAlignment.Center,
+			float? spacing = null)
 		{
 			_defaultAlignment = alignment;
 			_spacing = spacing ?? 4;


### PR DESCRIPTION
RadioButton and RadioGroup support for the following platforms: iOS, Android, macOS, UWP, WPF
This does not handle the Blazor target nor a Skia implementation.

The Android platform forced the implementation of a RadioGroup to match the UI structure for Android. This was not difficult to implement nor enforce on the other platforms and is not a serious detractor.  Consequently, having a RadioGroup made it easier to implement RadioButton support and handling grouping at a specific level in order to achieve the desired stateful effects of the radio buttons.

Sample Comet UI Usage:
 ```
[Body]
		View Body() => new VStack
		{
			new RadioGroup
			{
				new RadioButton(
					label: "Group 1: Option A",
					selected: true,
					onClick: () => System.Diagnostics.Debug.WriteLine("Option A selected")),
				new RadioButton(
					label: "Group 1: Option B",
					onClick: () => System.Diagnostics.Debug.WriteLine("Option B selected")),
				new RadioButton(
					label: "Group 1: Option C",
					onClick: () => System.Diagnostics.Debug.WriteLine("Option C selected")),
			},
			new RadioGroup(
				orientation: Orientation.Horizontal)
			{
				new RadioButton(
					label: "Implicit Group: Option 1",
					onClick: () => System.Diagnostics.Debug.WriteLine("Option 1 selected")),
				new RadioButton(
					label: "Implicit Group: Option 2",
					selected: true,
					onClick: () => System.Diagnostics.Debug.WriteLine("Option 2 selected")),
				new RadioButton(
					label: "Implicit Group: Option 3",
					onClick: () => System.Diagnostics.Debug.WriteLine("Option 3 selected"))
			}
		};
```