### PR TITLE
Fixed Android NewApp Quickstart Template

### DIFF
--- a/templates/base/.template.config/template.json
+++ b/templates/base/.template.config/template.json
@@ -135,11 +135,17 @@
             "replaces": "XamarinEssentialsSdk",
             "defaultValue": "1.3.0-pre"
         },
-        "XamarinFormsSdk": {
+        "XamarinAndroidAppCompat": {
             "type": "parameter",
             "dataType": "string",
-            "replaces": "XamarinFormsSdk",
-            "defaultValue": "4.4.0.991640"
+            "replaces": "XamarinAndroidAppCompat",
+            "defaultValue": "28.0.0.1"
+        },
+        "XamarinAndroidDesign": {
+            "type": "parameter",
+            "dataType": "string",
+            "replaces": "XamarinAndroidDesign",
+            "defaultValue": "28.0.0.1"
         },
         "CometSdk": {
             "type": "parameter",
@@ -151,7 +157,7 @@
             "type": "parameter",
             "dataType": "string",
             "replaces": "CometReloadSdk",
-            "defaultValue": "0.0.9-alpha"
+            "defaultValue": "0.0.13-alpha"
         },
         "ProjectID": {
             "type": "generated",

--- a/templates/base/.template.config/template.json
+++ b/templates/base/.template.config/template.json
@@ -135,6 +135,12 @@
             "replaces": "XamarinEssentialsSdk",
             "defaultValue": "1.3.0-pre"
         },
+        "XamarinFormsSdk": {
+            "type": "parameter",
+            "dataType": "string",
+            "replaces": "XamarinFormsSdk",
+            "defaultValue": "4.4.0.991640"
+        },
         "CometSdk": {
             "type": "parameter",
             "dataType": "string",

--- a/templates/quickstart/NewApp.Android/MainActivity.cs
+++ b/templates/quickstart/NewApp.Android/MainActivity.cs
@@ -26,7 +26,6 @@ namespace NewApp.Droid
             #if (IncludeXamarinEssentials)
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             #endif
-            global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
 #if DEBUG
             Comet.Reload.Init();
 #endif

--- a/templates/quickstart/NewApp.Android/MainActivity.cs
+++ b/templates/quickstart/NewApp.Android/MainActivity.cs
@@ -6,11 +6,12 @@ using Android.Runtime;
 using Android.Views;
 using Android.Widget;
 using Android.OS;
+using Comet.Android;
 
 namespace NewApp.Droid
 {
     [Activity(Label = "NewApp", Icon = "@mipmap/icon", Theme = "@style/MainTheme", MainLauncher = true, ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation)]
-    public class MainActivity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+    public class MainActivity : CometActivity
     {
         protected override void OnCreate(Bundle savedInstanceState)
         {
@@ -26,7 +27,11 @@ namespace NewApp.Droid
             Xamarin.Essentials.Platform.Init(this, savedInstanceState);
             #endif
             global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
-            LoadApplication(new App());
+#if DEBUG
+            Comet.Reload.Init();
+#endif
+
+            Page = new MainPage();
         }
         #if(IncludeXamarinEssentials)
         public override void OnRequestPermissionsResult(int requestCode, string[] permissions, [GeneratedEnum] Android.Content.PM.Permission[] grantResults)

--- a/templates/quickstart/NewApp.Android/NewApp.Android.csproj
+++ b/templates/quickstart/NewApp.Android/NewApp.Android.csproj
@@ -57,7 +57,8 @@
     #endif-->
   </ItemGroup>
   <ItemGroup>
-      <PackageReference Include="Xamarin.Forms" Version="XamarinFormsSdk" />
+      <PackageReference Include="Xamarin.Android.Support.v7.AppCompat" Version="XamarinAndroidAppCompat" />
+      <PackageReference Include="Xamarin.Android.Support.Design" Version="XamarinAndroidDesign" />
       <PackageReference Include="Xamarin.Essentials" Version="XamarinEssentialsSdk" />
       <PackageReference Include="Clancey.Comet.Reload" Version="CometReloadSdk"/>
       <PackageReference Include="Clancey.Comet" Version="CometSdk"/>

--- a/templates/quickstart/NewApp.Android/NewApp.Android.csproj
+++ b/templates/quickstart/NewApp.Android/NewApp.Android.csproj
@@ -57,6 +57,7 @@
     #endif-->
   </ItemGroup>
   <ItemGroup>
+      <PackageReference Include="Xamarin.Forms" Version="XamarinFormsSdk" />
       <PackageReference Include="Xamarin.Essentials" Version="XamarinEssentialsSdk" />
       <PackageReference Include="Clancey.Comet.Reload" Version="CometReloadSdk"/>
       <PackageReference Include="Clancey.Comet" Version="CometSdk"/>
@@ -96,15 +97,15 @@
     <Folder Include="Resources\drawable-xxhdpi\" />
     <Folder Include="Resources\drawable-xxxhdpi\" />
   </ItemGroup>
-  <!--#if (!CreateSharedProject)
+  <!--#if (CreateSharedProject)
   <ItemGroup>
     <ProjectReference Include="..\LibraryProjectName\LibraryProjectName.csproj">
-      <Project>{99E19497-29A6-4B77-B773-BEC55F9B55DC}</Project>
+      <Project>{032FBFD0-7AD6-4B97-8372-B94141CEA15C}</Project>
       <Name>LibraryProjectName</Name>
     </ProjectReference>
   </ItemGroup>
   #endif-->
-  <!--#if (CreateSharedProject)
+  <!--#if (!CreateSharedProject)
   <Import Project="..\LibraryProjectName\LibraryProjectName.projitems" Label="Shared" />
   #endif-->
  <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/templates/quickstart/NewApp.iOS/NewApp.iOS.csproj
+++ b/templates/quickstart/NewApp.iOS/NewApp.iOS.csproj
@@ -143,7 +143,7 @@
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="..\NewApp\NewApp.csproj">
-        <Project>{DC8AAC73-C9C3-4936-9F2B-EC8906A3A7E0}</Project>
+        <Project>{032FBFD0-7AD6-4B97-8372-B94141CEA15C}</Project>
         <Name>NewApp</Name>
       </ProjectReference>
     </ItemGroup>

--- a/templates/quickstart/NewApp.sln
+++ b/templates/quickstart/NewApp.sln
@@ -30,7 +30,6 @@ Global
 		{032FBFD0-7AD6-4B97-8372-B94141CEA15C}.Release|iPhone.ActiveCfg = Release|Any CPU
 		{032FBFD0-7AD6-4B97-8372-B94141CEA15C}.Release|iPhone.Build.0 = Release|Any CPU
 		{BA2C8415-B3DC-409B-980E-DDDA5A5345BD}.Debug|Any CPU.ActiveCfg = Debug|iPhoneSimulator
-		{BA2C8415-B3DC-409B-980E-DDDA5A5345BD}.Debug|Any CPU.Build.0 = Debug|iPhoneSimulator
 		{BA2C8415-B3DC-409B-980E-DDDA5A5345BD}.Release|Any CPU.ActiveCfg = Release|iPhoneSimulator
 		{BA2C8415-B3DC-409B-980E-DDDA5A5345BD}.Release|Any CPU.Build.0 = Release|iPhoneSimulator
 		{BA2C8415-B3DC-409B-980E-DDDA5A5345BD}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
@@ -41,5 +40,9 @@ Global
 		{BA2C8415-B3DC-409B-980E-DDDA5A5345BD}.Debug|iPhone.Build.0 = Debug|iPhone
 		{BA2C8415-B3DC-409B-980E-DDDA5A5345BD}.Release|iPhone.ActiveCfg = Release|iPhone
 		{BA2C8415-B3DC-409B-980E-DDDA5A5345BD}.Release|iPhone.Build.0 = Release|iPhone
+		{7FCB4590-5B53-4CF7-B00C-3722F34EB950}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FCB4590-5B53-4CF7-B00C-3722F34EB950}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7FCB4590-5B53-4CF7-B00C-3722F34EB950}.Release|Any CPU.ActiveCfg = Debug|Any CPU
+		{7FCB4590-5B53-4CF7-B00C-3722F34EB950}.Release|Any CPU.Build.0 = Debug|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/templates/quickstart/NewApp/MainPage.cs
+++ b/templates/quickstart/NewApp/MainPage.cs
@@ -13,7 +13,7 @@ namespace NewApp
             new Text(() => $"Value: {count.Value}")
                 .Color(Color.Black)
                 .FontSize(32),
-            new Button("Increment", () => count.Value ++ )
+            new Comet.Button("Increment", () => count.Value ++ )
                 .Frame(width:320, height:44)
                 .Background(Color.Black)
                 .Color(Color.White)

--- a/templates/quickstart/NewApp/MainPage.cs
+++ b/templates/quickstart/NewApp/MainPage.cs
@@ -13,7 +13,7 @@ namespace NewApp
             new Text(() => $"Value: {count.Value}")
                 .Color(Color.Black)
                 .FontSize(32),
-            new Comet.Button("Increment", () => count.Value ++ )
+            new Button("Increment", () => count.Value ++ )
                 .Frame(width:320, height:44)
                 .Background(Color.Black)
                 .Color(Color.White)


### PR DESCRIPTION
* Switch to WIP because of concerns being discussed over discord about 
  * Not adding the Xamarin.Forms package, and 
  * Not changing the `MainPage` class

**Core Changes**
------------
* Updated `MainPage` to completely qualify the Button, which made Hot Reload work. Hot Reload was not working because it was confused between Android.Widget.Button and Comet.Button
* Updated the `NewApp` solution file Configuration Mapping, so that switching to "Any CPU" config, sets up the droid project as startup, and allows building to emulator, and doesn't build the iOS project.

**Android Changes**
---------------
* Updated `MainActivity` to inherit from CometActivity, Load MainPage, and Initialize Comet Reload
* Updated the template.json to include the Xamarin Forms package needed by the Android MainAcitivity file
* Fixed the Android.csproj file so that it is loaded in the Solution in the right way

**Testing**
----------
* Tested the changes on a solution built with this template, and these were the changes I made to make it work on Android.
* Not a 100% sure it will all work because the solution requires shell scripting to setup, but I basically took a new template and recorded all the changes I had to make there, and re-enacted them on this soln file

**Known Issue**
-------------
* Android will crash once you navigate after a hot reload due to an IllegalStateException on the second time you try to hot reload:
```
[MonoDroid] UNHANDLED EXCEPTION:
[MonoDroid] Java.Lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
[MonoDroid]   at Java.Interop.JniEnvironment+InstanceMethods.CallNonvirtualVoidMethod (Java.Interop.JniObjectReference instance, Java.Interop.JniObjectReference type, Java.Interop.JniMethodInfo method, Java.Interop.JniArgumentValue* args) [0x0008e] in <af1c6fdcff1a4da4a0e44a8cdef352da>:0 
[MonoDroid]   at Java.Interop.JniPeerMembers+JniInstanceMethods.InvokeVirtualVoidMethod (System.String encodedMember, Java.Interop.IJavaPeerable self, Java.Interop.JniArgumentValue* parameters) [0x0005d] in <af1c6fdcff1a4da4a0e44a8cdef352da>:0 
[MonoDroid]   at Android.Views.ViewGroup.AddView (Android.Views.View child) [0x00031] in <d706cf8faf5542949900cf6d57864528>:0 
[MonoDroid]   at Comet.Android.Handlers.VStackHandler.UpdateChildren (Comet.VStack stack) [0x000ff] in d:\a\1\s\src\Comet.Android\Handlers\VStackHandler.cs:90 
[MonoDroid]   at Comet.Android.Handlers.VStackHandler.SetView (Comet.View view) [0x0000d] in d:\a\1\s\src\Comet.Android\Handlers\VStackHandler.cs:42 
[MonoDroid]   at Comet.View.set_ViewHandler (Comet.IViewHandler value) [0x00072] in d:\a\1\s\src\Comet\Controls\View.cs:105 
[MonoDroid]   at Comet.Android.AndroidExtensions.ToView (Comet.View view) [0x00030] in d:\a\1\s\src\Comet.Android\Extensions\AndroidExtensions.cs:40 
[MonoDroid]   at Comet.Android.Handlers.ViewHandler.CreateView (Android.Content.Context context) [0x00001] in d:\a\1\s\src\Comet.Android\Handlers\ViewHandler.cs:24 
[MonoDroid]   at Comet.Android.Handlers.AbstractHandler`2[TVirtualView,TNativeView].SetView (Comet.View view) [0x00012] in d:\a\1\s\src\Comet.Android\Handlers\AbstractHandler.cs:44 
[MonoDroid]   at Comet.View.ResetView () [0x00097] in d:\a\1\s\src\Comet\Controls\View.cs:145 
[MonoDroid]   at Comet.View.Reload () [0x00000] in d:\a\1\s\src\Comet\Controls\View.cs:125 
[MonoDroid]   at Java.Lang.Thread+RunnableImplementor.Run () [0x00008] in <d706cf8faf5542949900cf6d57864528>:0 
[MonoDroid]   at Java.Lang.IRunnableInvoker.n_Run (System.IntPtr jnienv, System.IntPtr native__this) [0x00009] in <d706cf8faf5542949900cf6d57864528>:0 
[MonoDroid]   at (wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.16(intptr,intptr)
[MonoDroid]   --- End of managed Java.Lang.IllegalStateException stack trace ---
[MonoDroid] java.lang.IllegalStateException: The specified child already has a parent. You must call removeView() on the child's parent first.
[MonoDroid] 	at android.view.ViewGroup.addViewInner(ViewGroup.java:5034)
[MonoDroid] 	at android.view.ViewGroup.addView(ViewGroup.java:4865)
[MonoDroid] 	at android.view.ViewGroup.addView(ViewGroup.java:4805)
[MonoDroid] 	at android.view.ViewGroup.addView(ViewGroup.java:4778)
[MonoDroid] 	at mono.java.lang.RunnableImplementor.n_run(Native Method)
[MonoDroid] 	at mono.java.lang.RunnableImplementor.run(RunnableImplementor.java:30)
[MonoDroid] 	at android.os.Handler.handleCallback(Handler.java:873)
[MonoDroid] 	at android.os.Handler.dispatchMessage(Handler.java:99)
[MonoDroid] 	at android.os.Looper.loop(Looper.java:193)
[MonoDroid] 	at android.app.ActivityThread.main(ActivityThread.java:6669)
[MonoDroid] 	at java.lang.reflect.Method.invoke(Native Method)
[MonoDroid] 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:493)
[MonoDroid] 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:858)
[MonoDroid] 
```